### PR TITLE
The case of the missing corpse and parade -- solved

### DIFF
--- a/action/action.serve.rb
+++ b/action/action.serve.rb
@@ -17,9 +17,14 @@ class ActionServe
 
   def act params = nil
 
+    @host.corpse.metas = ""
+    @host.corpse.scripts = ""
+    @host.corpse.links = ""
+    @host.corpse.footers = ""
+
     @host.corpse.build
     @host.corpse.query(params)
-    
+
     return @host.corpse.to_html
 
   end

--- a/corpse/corpse.http/corpse.rb
+++ b/corpse/corpse.http/corpse.rb
@@ -12,6 +12,9 @@ class CorpseHttp
 
   attr_accessor :title
   attr_accessor :metas
+  attr_accessor :links
+  attr_accessor :scripts
+  attr_accessor :footers
   attr_accessor :body
   attr_accessor :style
 

--- a/nataniev.server.rb
+++ b/nataniev.server.rb
@@ -12,11 +12,12 @@ configure do
   enable :cross_origin
 end
 
+$nataniev = Nataniev.new
+
 get '/' do
 
   headers( "Access-Control-Allow-Origin" => "*" )
-  $nataniev = Nataniev.new
-  
+
   v = ARGV.first ? ARGV.first : "ghost"
   if request.base_url.include? "xxiivv" then v = "landing" end
   if request.base_url.include? "wiki" then v = "oscean" end
@@ -27,13 +28,12 @@ get '/' do
   if request.base_url.include? ":maeve" then v = "maeve" end
   a = $nataniev.answer("#{v} serve home")
   "#{a}"
-  
+
 end
 
 get '/:task' do
 
   headers( "Access-Control-Allow-Origin" => "*" )
-  $nataniev = Nataniev.new
 
   v = ARGV.first ? ARGV.first : "ghost"
   if request.base_url.include? "xxiivv" then v = "landing" end

--- a/nataniev.server.rb
+++ b/nataniev.server.rb
@@ -45,7 +45,7 @@ get '/:task' do
   if params[:task].include? ":maeve" then v = "maeve" end
   a = $nataniev.answer("#{v} serve "+params[:task])
   "#{a}"
-  
+
 end
 
 post '/ide.save' do
@@ -80,7 +80,7 @@ post '/ide.tree' do
     # if !["ma","mh","rb","js","css","html"].include?(ext) then next end
     a.push(file)
   end
-  
+
   return a.to_json
 
 end
@@ -92,7 +92,7 @@ post '/diary.load' do
   h = {}
   h[:oscean] = $nataniev.summon(:oscean).new.act(:query,"diary")
   h[:grimgrains] = $nataniev.summon(:grimgrains).new.act(:query,"diary")
-  
+
   return h.to_json
 
 end
@@ -107,7 +107,7 @@ post '/dict.load' do
   Memory_Array.new("dict.lietal",Nataniev.new.path).to_a.each do |word|
     if !h[word["ENGLISH"]] then h[word["ENGLISH"]] = {} end
     h[word["ENGLISH"]][:lietal] = word["LIETAL"]
-  end  
+  end
   return h.to_json
 
 end

--- a/system/nataniev.rb
+++ b/system/nataniev.rb
@@ -15,7 +15,7 @@ class Nataniev
     @time = Time.new
     @path = File.expand_path(File.join(File.dirname(__FILE__), "/"))+"/.."
     @vessels = {}
-    
+
     load "#{@path}/system/action.rb"
     load "#{@path}/system/corpse.rb"
     load "#{@path}/system/vessel.rb"
@@ -52,7 +52,7 @@ class Nataniev
   def vessel
 
     return @vessels.first
-    
+
   end
 
 
@@ -73,7 +73,7 @@ class Nataniev
     elsif File.exist?("#{path}/#{cat}/core.#{name}/#{cat}.rb")
       require_relative "#{path}/#{cat}/core.#{name}/#{cat}.rb"
     end
-    
+
   end
 
 end
@@ -91,7 +91,7 @@ end
 def load_folder path
 
   Dir[path].each do |file_name|
-    if file_name.to_s.length < 5 then next end  
+    if file_name.to_s.length < 5 then next end
     if file_name[-3,3] != ".rb" then next end
     load file_name
   end
@@ -109,7 +109,7 @@ end
 def require_folder path
 
   Dir[path].each do |file_name|
-    if file_name.to_s.length < 5 then next end  
+    if file_name.to_s.length < 5 then next end
     if file_name[-3,3] != ".rb" then next end
     require file_name
   end

--- a/system/nataniev.rb
+++ b/system/nataniev.rb
@@ -37,9 +37,11 @@ class Nataniev
 
   end
 
-  def summon invoke 
+  def summon invoke
 
-    @vessels[invoke.to_sym] = Ghost.new(invoke)    
+    if @vessels[invoke.to_sym] then return @vessels[invoke.to_sym] end
+
+    @vessels[invoke.to_sym] = Ghost.new(invoke)
 
     load_any("#{@path}/vessel/vessel.#{invoke.downcase}","invoke")
 


### PR DESCRIPTION
So, my hypothesis about the cause of the bugs in Paradise were correct, but my PRs were ultimately fruitless since it was still happening some even when waiting around for corpse and parade to be set. I traced the issue all the way to how `nataniev.server.rb` was calling things.

tl;dr -- this fixes Paradise, **but is a bit of a fundamental change that affects some assumptions you make in other vessels**. It only has to do with building the http corpses, and I explain at the bottom, but I say that so that you can hopefully pull things down, check it out yourself and make sure I'm right before you push it up to your servers :P 

I poked around quite a bit tho, and this seems to not affect any other vessel...I was able to serve Oscean, Grimgrains, Paradise etc. with no observable change in behavior. You should actually see a slight performance boost since you're not instantiating all of Nataniev AND the whole vessel every time an HTTP request is made ;)

So here's what was happening: I realized that the `summon` method in `nataniev.rb` was creating a completely new instance of the vessel every time it was called. This was causing all of the data in `$nataniev.vessels[:vessel]` to be lost. So that explains why the corpse was missing randomly. So I decided to just try returning the vessel if it already exists in `$nataniev.vessels`. But for some reason, it was never finding paradise in the vessels. THEN I realized that `$nataniev` was getting set within the `get '/'` and `get '/:task'` blocks. Every time a request would hit the server at `/` or `/:task`, it would blow away the existing global `$nataniev` variable and create a new instance of Nataniev. This would cause all of the existing vessel data to be lost. No wonder! This was happening even when the request for the favicon would come in. Ker-blam Nataniev.

It seemed like this was not the desired behavior, so now I just set it once when Sinatra gets spun up. Bug fixed! Well, almost. I noticed that the script and link tags were getting duplicated in the HTML that the corpse was spitting out, and I saw that it's because the generic serve action builds the corpse every call. So every time I'd navigate to a different page, it would just append all those tags again. Since previously the corpse was getting blown away every HTTP request, this wasn't obvious. 

So, my fix for that is to just blank out those attributes, but a better solution would probably be to only 'build' upon initialization, since you really only need to do that once.

Such a little change for such a headache of a bug 😖 